### PR TITLE
Adding CPU and MPS Support to gligen_inference.py

### DIFF
--- a/demo/environment.yaml
+++ b/demo/environment.yaml
@@ -1,6 +1,6 @@
 name: gligen_demo
 channels:
-  - xformers/label/dev
+  - xformers
   - pytorch
   - defaults
 dependencies:
@@ -10,7 +10,7 @@ dependencies:
   - pytorch=1.12.1
   - torchvision=0.13.1
   - numpy=1.23.1
-  - xformers
+  - xformers=0.0.22
   - pip:
     - omegaconf==2.1.1
     - albumentations==1.3.0

--- a/ldm/util.py
+++ b/ldm/util.py
@@ -84,3 +84,12 @@ def get_obj_from_str(string, reload=False):
         module_imp = importlib.import_module(module)
         importlib.reload(module_imp)
     return getattr(importlib.import_module(module, package=None), cls)
+
+
+def default_device() -> str:
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.backends.mps.is_available():
+        return "mps"
+    else:
+        return "cpu"


### PR DESCRIPTION
**Adding CPU and MPS Support to gligen_inference.py**

So people without **GPUs** can also run GLIGEN inference.py without issues.